### PR TITLE
add the draw history functionality in the frontend

### DIFF
--- a/backend/go.sum
+++ b/backend/go.sum
@@ -126,6 +126,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/p
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 h1:Hynbrlo6LbYI3H1IqXpkVDOcX/3HiPdhVEuyj5a59RM=
 golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/frontend/src/modules/scribble/components/Canvas.vue
+++ b/frontend/src/modules/scribble/components/Canvas.vue
@@ -95,6 +95,10 @@ export default {
       this.$emit("drawAction", drawAction);
     },
 
+    requestHistory: function() {
+      this.$emit("requestHistory");
+    },
+
     draw: function(drawAction) {
       this.context.beginPath();
       this.context.moveTo(drawAction.from.x, drawAction.from.y);

--- a/frontend/src/modules/scribble/components/Canvas.vue
+++ b/frontend/src/modules/scribble/components/Canvas.vue
@@ -95,10 +95,6 @@ export default {
       this.$emit("drawAction", drawAction);
     },
 
-    requestHistory: function() {
-      this.$emit("requestHistory");
-    },
-
     draw: function(drawAction) {
       this.context.beginPath();
       this.context.moveTo(drawAction.from.x, drawAction.from.y);

--- a/frontend/src/modules/scribble/components/CanvasPanel.vue
+++ b/frontend/src/modules/scribble/components/CanvasPanel.vue
@@ -17,7 +17,7 @@ import Canvas from "./Canvas.vue";
 import BrushSelector from "./BrushSelector.vue";
 import { createBrushStyle } from "../utility/BrushStyleUtils";
 import { EventBus } from "@/eventBus.js";
-import { createWebSocketMessage } from "../utility/WebSocketMessageUtils";
+import { createDrawMessage } from "../utility/WebSocketMessageUtils";
 
 export default {
   name: "CanvasPanel",
@@ -45,7 +45,7 @@ export default {
 
   methods: {
     sendDrawAction(drawAction) {
-      let drawMsg = createWebSocketMessage("draw", {
+      let drawMsg = createDrawMessage({
         action: drawAction,
         requestHistory: false
       });
@@ -53,7 +53,7 @@ export default {
     },
 
     sendRequestHistory() {
-      let requestHistoryMsg = createWebSocketMessage("draw", {
+      let requestHistoryMsg = createDrawMessage({
         requestHistory: true
       });
       this.$webSocketService.send(requestHistoryMsg);
@@ -65,7 +65,9 @@ export default {
           this.$refs["canvas"].draw(action);
         }
       }
-      this.$refs["canvas"].draw(drawMessage.action);
+      if (drawMessage.action != undefined) {
+        this.$refs["canvas"].draw(drawMessage.action);
+      }
     }
   }
 };

--- a/frontend/src/modules/scribble/utility/WebSocketMessageUtils.js
+++ b/frontend/src/modules/scribble/utility/WebSocketMessageUtils.js
@@ -2,10 +2,6 @@ export function createChatMessage(message) {
   return createWebSocketMessage("chat", { message: message });
 }
 
-export function createDrawActionMessage(drawAction) {
-  return createWebSocketMessage("draw", { action: drawAction, requestHistory: false });
-}
-
 export function createWebSocketMessage(api, payload) {
   return {
     api: api,

--- a/frontend/src/modules/scribble/utility/WebSocketMessageUtils.js
+++ b/frontend/src/modules/scribble/utility/WebSocketMessageUtils.js
@@ -2,6 +2,10 @@ export function createChatMessage(message) {
   return createWebSocketMessage("chat", { message: message });
 }
 
+export function createDrawMessage(payload) {
+  return createWebSocketMessage("draw", payload);
+}
+
 export function createWebSocketMessage(api, payload) {
   return {
     api: api,

--- a/frontend/src/services/eventHandlerService.js
+++ b/frontend/src/services/eventHandlerService.js
@@ -2,13 +2,9 @@ import { GlobalStore } from '@/modules/common/store/globalstore/index';
 import { EventBus } from '../eventBus.js';
 
 export default class EventHandlerService {
-    constructor() {}
+    constructor() { }
 
     handle(api, payload) {
-        console.log("from eventHandlerService");
-        console.log(api);
-        console.log(payload)
-
         if (api === "hub") {
             this.handleHubEvent(payload);
         }
@@ -17,7 +13,6 @@ export default class EventHandlerService {
     }
 
     handleHubEvent(payload) {
-        console.log(payload)
         if (payload.connectedClients != null) {
             GlobalStore.commit('setPlayers', payload.connectedClients);
         }


### PR DESCRIPTION
This commit also removes one of the websocketmessageutils since it made
it really hard to use and hides out some important details

Now when making a message, it is more clear what needs to happen
especially when you have the draw.go struct on another window. It is
clear what the struct in the frontend should look like.

Used the following link to convert .mp4 to GIF for this PR attachment
https://askubuntu.com/a/837574

![draw-history](https://user-images.githubusercontent.com/12277640/87873585-13003900-c980-11ea-946e-94bce93e43a9.gif)